### PR TITLE
Fallback To UIKit attributes if Core Text attributes are not present

### DIFF
--- a/Source/CSimpleHTMLParser.m
+++ b/Source/CSimpleHTMLParser.m
@@ -60,6 +60,7 @@ NSString *const kSimpleHTMLParserErrorDomain = @"kSimpleHTMLParserErrorDomain";
     static dispatch_once_t sOnceToken;
     dispatch_once(&sOnceToken, ^{
         sEntities = @{
+            @"#39":@"'",
 			@"quot": @"\"",
             @"amp": @"&",
             @"apos": @"'",

--- a/Source/NSAttributedString_Extensions.m
+++ b/Source/NSAttributedString_Extensions.m
@@ -36,7 +36,11 @@ NSString *const kMarkupOutlineAttributeName = @"com.touchcode.outline";
             {
             theFont = [UIFont fontWithCTFont:theCTFont];
             }
-        
+        else if (attrs[NSFontAttributeName] != NULL)
+            {
+            theFont = attrs[NSFontAttributeName];
+            }
+
         attrs = [self normalizeAttributes:attrs baseFont:theFont];
         [theString setAttributes:attrs range:range];
         }];

--- a/Source/NSCharacterSet_HTMLExtensions.h
+++ b/Source/NSCharacterSet_HTMLExtensions.h
@@ -11,5 +11,6 @@
 @interface NSCharacterSet (HTMLExtensions)
 
 + (NSCharacterSet *)quoteCharacterSet;
++ (NSCharacterSet *)spaceAndCloseTagCharacterSet;
 
 @end

--- a/Source/NSCharacterSet_HTMLExtensions.m
+++ b/Source/NSCharacterSet_HTMLExtensions.m
@@ -20,4 +20,14 @@
   return _quoteCharacterSet;
 }
 
++ (NSCharacterSet *)spaceAndCloseTagCharacterSet {
+  static NSCharacterSet *_characterSet;
+  static dispatch_once_t predicate;
+  dispatch_once(&predicate, ^{
+    _characterSet = [NSCharacterSet characterSetWithCharactersInString:@" >"];
+  });
+
+  return _characterSet;
+}
+
 @end

--- a/Source/NSScanner_HTMLExtensions.m
+++ b/Source/NSScanner_HTMLExtensions.m
@@ -69,16 +69,17 @@
 
         if ([self scanString:@"=" intoString:NULL] == YES)
             {
-            if ([self scanCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:NULL] == NO)
+            if ([self scanCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:NULL] == YES)
                 {
-                self.scanLocation = theSavedScanLocation;
-                self.charactersToBeSkipped = theSavedCharactersToBeSkipped;
-                return(NO);
+                [self scanUpToCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:&theAttributeValue];
+                if ([self scanCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:NULL] == NO)
+                    {
+                    self.scanLocation = theSavedScanLocation;
+                    self.charactersToBeSkipped = theSavedCharactersToBeSkipped;
+                    return(NO);
+                    }
                 }
-
-            [self scanUpToCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:&theAttributeValue];
-
-            if ([self scanCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:NULL] == NO)
+            else if ([self scanUpToCharactersFromSet:[NSCharacterSet spaceAndCloseTagCharacterSet] intoString:&theAttributeValue] == NO)
                 {
                 self.scanLocation = theSavedScanLocation;
                 self.charactersToBeSkipped = theSavedCharactersToBeSkipped;
@@ -185,16 +186,17 @@
 
         if ([self scanString:@"=" intoString:NULL] == YES)
             {
-            if ([self scanCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:NULL] == NO)
+            if ([self scanCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:NULL] == YES)
                 {
-                self.scanLocation = theSavedScanLocation;
-                self.charactersToBeSkipped = theSavedCharactersToBeSkipped;
-                return(NO);
+                [self scanUpToCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:&theAttributeValue];
+                if ([self scanCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:NULL] == NO)
+                    {
+                    self.scanLocation = theSavedScanLocation;
+                    self.charactersToBeSkipped = theSavedCharactersToBeSkipped;
+                    return(NO);
+                    }
                 }
-
-            [self scanUpToCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:&theAttributeValue];
-
-            if ([self scanCharactersFromSet:[NSCharacterSet quoteCharacterSet] intoString:NULL] == NO)
+            else if ([self scanUpToCharactersFromSet:[NSCharacterSet spaceAndCloseTagCharacterSet] intoString:&theAttributeValue] == NO)
                 {
                 self.scanLocation = theSavedScanLocation;
                 self.charactersToBeSkipped = theSavedCharactersToBeSkipped;


### PR DESCRIPTION
Starting in iOS 8, passing some UIKit text attributes stopped working. For example, in iOS 7, you could create an attributed string like:

    NSDictionary *attrs = @{NSForegroundColorAttributedName: [UIColor redColor]
    NSAttributedString *s = [[NSAttributedString alloc] initWithString:@"Foo" attributes:attrs];

In iOS 8, this font color would always be overridden by the default CCoreTextLabel textColor unless you passed in kCTForegroundColorAttributeName instead. It seems like there was some aliasing between the two styles of properties before that is no longer present.

I've added explicit fallbacks here to preserve the old behavior.